### PR TITLE
Customisable stats

### DIFF
--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_rollermine.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_rollermine.lua
@@ -84,8 +84,10 @@ function SWEP:DeployRollermine()
       if IsValid(rollermine) then
          self.Planted = true
 
+         rollermine:SetHealth(GetConVar("weapon_ttt_rollermine_health"):GetFloat())
          rollermine:SetPos(vsrc + vang * 10)
-         rollermine:SetOwner(ply)
+         rollermine.Deployer = ply
+         rollermine.IsTraitorRollermine = true
          rollermine:Spawn()
          rollermine:Activate()
          

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_rollermine.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_rollermine.lua
@@ -46,12 +46,6 @@ SWEP.Primary.Automatic      = true
 SWEP.Primary.Ammo           = "none"
 SWEP.Primary.Delay          = 5.0
 
-SWEP.Secondary.ClipSize     = -1
-SWEP.Secondary.DefaultClip  = -1
-SWEP.Secondary.Automatic    = true
-SWEP.Secondary.Ammo         = "none"
-SWEP.Secondary.Delay        = 1.0
-
 SWEP.NoSights               = true
 
 local throwsound = Sound( "Weapon_SLAM.SatchelThrow" )

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_rollermine.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_rollermine.lua
@@ -79,7 +79,7 @@ function SWEP:DeployRollermine()
          self.Planted = true
 
          rollermine:SetHealth(GetConVar("weapon_ttt_rollermine_health"):GetFloat())
-         rollermine:SetPos(vsrc + vang * 10)
+         rollermine:SetPos(vsrc + vang * 50)
          rollermine.Deployer = ply
          rollermine.IsTraitorRollermine = true
          rollermine:Spawn()

--- a/lua/autorun/server/weapon_ttt_rollermine_damage.lua
+++ b/lua/autorun/server/weapon_ttt_rollermine_damage.lua
@@ -1,11 +1,11 @@
-local cvarOptions = FCVAR_ARCHIVE + FCVAR_REPLICATED + FCVAR_SERVER_CAN_EXECUTE + FCVAR_SERVER_CAN_EXECUTE
+local cvarOptions = FCVAR_ARCHIVE + FCVAR_REPLICATED + FCVAR_SERVER_CAN_EXECUTE
 
 CreateConVar("weapon_ttt_rollermine_damage_scale", 1.5, cvarOptions,
              "The multiplier applied to rollermine damage. When set to 1, 5HP damage will be done from side attacks and 10HP from others. (Default: 1.5)")
 
 CreateConVar("weapon_ttt_rollermine_health", 2500, cvarOptions,
              "Rollermine health. (Default: 2500)")
-             
+
 CreateConVar("weapon_ttt_rollermine_explosion_damage", 75, cvarOptions,
              "Maximum damage from rollermine death explosion. (Default: 75)")
 
@@ -37,7 +37,7 @@ end
 hook.Add("EntityTakeDamage", "weapon_ttt_rollermine_damage", CheckRollermineDamage)
 
 function ScaleRollermineKnockback(damageForce)
-   -- Default damage force allows rollermines to fly away. We'll nurf that a bit.
+   -- Decreases default damage force, which means rollermines fly very far away when shot.
    local forceDistance = damageForce:Length()
    local targetDistance = math.min(forceDistance, 30000)
    local distanceRatio = targetDistance / forceDistance
@@ -51,25 +51,26 @@ function DamageRollermine(rollermine, damage)
    
    if currentHealth - damage <= 0 then
       rollermine.RollermineDestructionPhase = true
-      rollermine:Fire("IgniteLifetime", 3)
+      rollermine:Fire("IgniteLifetime", 5)
       rollermine:SetHealth(0)
       
       local uniqueTimerName = "weapon_ttt_rollermine"..rollermine:EntIndex()
-      timer.Create(uniqueTimerName, 3, 1, function()
-
-         local explode = ents.Create( "env_explosion" )
-            explode:SetPos(rollermine:GetPos())
-            if IsValid(rollermine.Deployer) then explode:SetOwner(rollermine.Deployer) end
-            explode:Spawn()
-            explode:SetKeyValue("iMagnitude", GetConVar("weapon_ttt_rollermine_explosion_damage"):GetFloat())
-            explode:SetKeyValue("iRadiusOverride", "350")
-            explode:Fire("Explode", 0, 0)
-            explode:EmitSound("NPC_RollerMine.ExplodeChirpRespond", 100, 100)
-
-         rollermine:Fire("kill")
-      end)
+      timer.Create(uniqueTimerName, 3, 1, function() KillRollermine(rollermine) end)
       
    else
       rollermine:SetHealth(currentHealth - damage)
    end
+end
+
+function KillRollermine(rollermine)
+   local explode = ents.Create( "env_explosion" )
+      explode:SetPos(rollermine:GetPos())
+      if IsValid(rollermine.Deployer) then explode:SetOwner(rollermine.Deployer) end
+      explode:Spawn()
+      explode:SetKeyValue("iMagnitude", GetConVar("weapon_ttt_rollermine_explosion_damage"):GetFloat())
+      explode:SetKeyValue("iRadiusOverride", "400")
+      explode:Fire("Explode", 0, 0)
+      explode:EmitSound("NPC_RollerMine.ExplodeChirpRespond")
+
+   rollermine:Fire("kill")
 end

--- a/lua/autorun/server/weapon_ttt_rollermine_damage.lua
+++ b/lua/autorun/server/weapon_ttt_rollermine_damage.lua
@@ -1,0 +1,75 @@
+local cvarOptions = FCVAR_ARCHIVE + FCVAR_REPLICATED + FCVAR_SERVER_CAN_EXECUTE + FCVAR_SERVER_CAN_EXECUTE
+
+CreateConVar("weapon_ttt_rollermine_damage_scale", 1.5, cvarOptions,
+             "The multiplier applied to rollermine damage. When set to 1, 5HP damage will be done from side attacks and 10HP from others. (Default: 1.5)")
+
+CreateConVar("weapon_ttt_rollermine_health", 2500, cvarOptions,
+             "Rollermine health. (Default: 2500)")
+             
+CreateConVar("weapon_ttt_rollermine_explosion_damage", 75, cvarOptions,
+             "Maximum damage from rollermine death explosion. (Default: 75)")
+
+function CheckRollermineDamage( target, dmginfo )
+   if target:IsPlayer() and dmginfo:GetAttacker().IsTraitorRollermine then
+      
+      local attacker = dmginfo:GetAttacker()
+      
+      if target == attacker.Deployer then
+         dmginfo:SetDamage(0)
+      else
+         local damageScale = GetConVar("weapon_ttt_rollermine_damage_scale"):GetFloat()
+         dmginfo:SetDamage(dmginfo:GetDamage() * damageScale)
+         
+         if attacker.Deployer and IsValid(attacker.Deployer) then
+            dmginfo:SetAttacker(attacker.Deployer)
+         end
+      end
+      
+   elseif target.IsTraitorRollermine then
+      dmginfo:SetDamageForce(ScaleRollermineKnockback(dmginfo:GetDamageForce()))
+      
+      if not target.RollermineDestructionPhase then
+         DamageRollermine(target, dmginfo:GetDamage())
+      end
+   end
+end
+
+hook.Add("EntityTakeDamage", "weapon_ttt_rollermine_damage", CheckRollermineDamage)
+
+function ScaleRollermineKnockback(damageForce)
+   -- Default damage force allows rollermines to fly away. We'll nurf that a bit.
+   local forceDistance = damageForce:Length()
+   local targetDistance = math.min(forceDistance, 30000)
+   local distanceRatio = targetDistance / forceDistance
+   
+   damageForce:Mul(distanceRatio)
+   return damageForce
+end
+
+function DamageRollermine(rollermine, damage)
+   local currentHealth = rollermine:Health()
+   
+   if currentHealth - damage <= 0 then
+      rollermine.RollermineDestructionPhase = true
+      rollermine:Fire("IgniteLifetime", 3)
+      rollermine:SetHealth(0)
+      
+      local uniqueTimerName = "weapon_ttt_rollermine"..rollermine:EntIndex()
+      timer.Create(uniqueTimerName, 3, 1, function()
+
+         local explode = ents.Create( "env_explosion" )
+            explode:SetPos(rollermine:GetPos())
+            if IsValid(rollermine.Deployer) then explode:SetOwner(rollermine.Deployer) end
+            explode:Spawn()
+            explode:SetKeyValue("iMagnitude", GetConVar("weapon_ttt_rollermine_explosion_damage"):GetFloat())
+            explode:SetKeyValue("iRadiusOverride", "350")
+            explode:Fire("Explode", 0, 0)
+            explode:EmitSound("NPC_RollerMine.ExplodeChirpRespond", 100, 100)
+
+         rollermine:Fire("kill")
+      end)
+      
+   else
+      rollermine:SetHealth(currentHealth - damage)
+   end
+end


### PR DESCRIPTION
* Added configurable rollermine damage using a damage scale. 
    * weapon_ttt_rollermine_damage_scale
    * Default scale of 1.5
    * Side attacks = scale x 5HP
    * All other attacks = scale x 10HP
* Added configurable rollermine health
    * weapon_ttt_rollermine_health
    * Default value of 2500HP
* Added explosion damage 3 seconds after rollermine death
    * weapon_ttt_rollermine_explosion_damage
    * Default max damage is 75HP
* Reduced knockback on the rollermine when shot
* Set traitor who threw rollermine as cause of rollermine damage
* Changed rollermine to appear to shock the player who threw it, but no damage will be done
* Stops the rollermine from spawning inside the player